### PR TITLE
feat(UI): added daily activities and functionality

### DIFF
--- a/frontend/src/app/components/activitySelector.tsx
+++ b/frontend/src/app/components/activitySelector.tsx
@@ -23,9 +23,14 @@ import { Props } from "next/script";
 interface props {
   activityGroups: ActivityGroup[];
   setActivityGroups: (activityGroups: ActivityGroup[]) => void;
+  addToDailyPlan: (activity: Place) => void; // New prop
 }
 
-const ActivitySelector = ({ activityGroups, setActivityGroups }: props) => {
+const ActivitySelector = ({
+  activityGroups,
+  setActivityGroups,
+  addToDailyPlan,
+}: props) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   // State to track new activity input
@@ -132,7 +137,7 @@ const ActivitySelector = ({ activityGroups, setActivityGroups }: props) => {
                     Delete Group
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem>Add to Map</DropdownMenuItem>
+                  <DropdownMenuItem>Open / Close</DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
@@ -161,7 +166,11 @@ const ActivitySelector = ({ activityGroups, setActivityGroups }: props) => {
                             Remove
                           </DropdownMenuItem>
                           <DropdownMenuSeparator />
-                          <DropdownMenuItem>Add To Daily Plan</DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => addToDailyPlan(activity)}
+                          >
+                            Add To Daily Plan
+                          </DropdownMenuItem>
                         </DropdownMenuContent>
                       </DropdownMenu>
                     </div>
@@ -177,5 +186,95 @@ const ActivitySelector = ({ activityGroups, setActivityGroups }: props) => {
       </div>
     </>
   );
+
+  // return (
+  //   <>
+  //     <div className="activity-selector-header">
+  //       <h2 className="activity-title">Activities</h2>
+  //       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+  //         <DialogTrigger>
+  //           <i
+  //             className="fas fa-plus"
+  //             onClick={() => setIsDialogOpen(true)}
+  //           ></i>
+  //         </DialogTrigger>
+  //         <DialogContent>
+  //           <DialogHeader>
+  //             <DialogTitle>Add a New Activity Group</DialogTitle>
+  //             <DialogDescription>
+  //               Please enter the title of your new Activity Group.
+  //             </DialogDescription>
+  //             <Input
+  //               value={newActivityTitle}
+  //               onChange={(e) => setNewActivityTitle(e.target.value)}
+  //               placeholder="Enter activity title"
+  //             />
+  //             <Button onClick={handleAddActivity}>Create</Button>
+  //           </DialogHeader>
+  //         </DialogContent>
+  //       </Dialog>
+  //     </div>
+
+  //     <div className="activity-list">
+  //       {activityGroups.map((group) => (
+  //         <div key={group.id} className="activity-group">
+  //           <div className="group-header" onClick={() => toggleGroup(group.id)}>
+  //             <span className="group-title">{group.title}</span>
+  //             <DropdownMenu>
+  //               <DropdownMenuTrigger>
+  //                 <i className="fa-solid fa-ellipsis group-options"></i>
+  //               </DropdownMenuTrigger>
+  //               <DropdownMenuContent>
+  //                 <DropdownMenuItem
+  //                   onClick={() => handleRemoveActivityGroup(group.id)}
+  //                 >
+  //                   Delete Group
+  //                 </DropdownMenuItem>
+  //                 <DropdownMenuSeparator />
+  //                 <DropdownMenuItem>Add to Daily Plan</DropdownMenuItem>
+  //               </DropdownMenuContent>
+  //             </DropdownMenu>
+  //           </div>
+
+  //           {openGroup === group.id && (
+  //             <div className="activity-items-container space-y-4 pt-2">
+  //               {group.activities.map((activity, index) => (
+  //                 <div
+  //                   key={index}
+  //                   className="activity-item relative bg-gray-100 border border-gray-300 p-4 rounded-lg shadow-sm"
+  //                 >
+  //                   <div className="flex justify-between items-center">
+  //                     <span className="text-xl font-semibold text-gray-800">
+  //                       {activity.Name}
+  //                     </span>
+  //                     <DropdownMenu>
+  //                       <DropdownMenuTrigger>
+  //                         <i className="fa-solid fa-ellipsis cursor-pointer text-gray-500 absolute top-2 right-3"></i>
+  //                       </DropdownMenuTrigger>
+  //                       <DropdownMenuContent>
+  //                         <DropdownMenuItem
+  //                           onClick={() =>
+  //                             handleRemoveActivity(group.id, index)
+  //                           }
+  //                         >
+  //                           Remove
+  //                         </DropdownMenuItem>
+  //                         <DropdownMenuSeparator />
+  //                         <DropdownMenuItem>Add To Daily Plan</DropdownMenuItem>
+  //                       </DropdownMenuContent>
+  //                     </DropdownMenu>
+  //                   </div>
+  //                   <h1 className="text-sm text-gray-600 mb-4">
+  //                     {activity.Address}
+  //                   </h1>
+  //                 </div>
+  //               ))}
+  //             </div>
+  //           )}
+  //         </div>
+  //       ))}
+  //     </div>
+  //   </>
+  // );
 };
 export default ActivitySelector;

--- a/frontend/src/app/components/activitySelector.tsx
+++ b/frontend/src/app/components/activitySelector.tsx
@@ -19,8 +19,8 @@ import {
 import { Input } from "@/components/ui/input";
 import { useState } from "react";
 import { ActivityGroup, Place } from "@/lib/utils";
-import { Props } from "next/script";
-interface props {
+
+interface Props {
   activityGroups: ActivityGroup[];
   setActivityGroups: (activityGroups: ActivityGroup[]) => void;
   addToDailyPlan: (activity: Place) => void; // New prop
@@ -30,34 +30,15 @@ const ActivitySelector = ({
   activityGroups,
   setActivityGroups,
   addToDailyPlan,
-}: props) => {
+}: Props) => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-
-  // State to track new activity input
   const [newActivityTitle, setNewActivityTitle] = useState("");
-
-  // State to track the currently open group
   const [openGroup, setOpenGroup] = useState<string | null>(null);
 
   // Function to toggle group dropdown
   const toggleGroup = (id: string) => {
     setOpenGroup((prevOpenGroup) => (prevOpenGroup === id ? null : id));
   };
-
-  // Old functionality unsure if we will need to refactor to this old version later on so keep for now ??
-  // // Function to handle adding new activity group
-  // const handleAddActivity = () => {
-  //   if (newActivityTitle.trim()) {
-  //     const newItem = new ActivityGroup(
-  //       `group-${activityGroups.length + 1}`,
-  //       newActivityTitle,
-  //       []
-  //     );
-  //     setActivityGroups([...activityGroups, newItem]);
-  //     setNewActivityTitle("");
-  //     setIsDialogOpen(false);
-  //   }
-  // };
 
   // Function to handle adding a new activity group
   const handleAddActivity = () => {
@@ -67,7 +48,6 @@ const ActivitySelector = ({
         newActivityTitle,
         []
       );
-      // Ensure newItem is an instance of ActivityGroup
       setActivityGroups([...activityGroups, newItem]);
       setNewActivityTitle("");
       setIsDialogOpen(false);
@@ -93,6 +73,7 @@ const ActivitySelector = ({
       )
     );
   };
+
   return (
     <>
       <div className="activity-selector-header">
@@ -186,95 +167,6 @@ const ActivitySelector = ({
       </div>
     </>
   );
-
-  // return (
-  //   <>
-  //     <div className="activity-selector-header">
-  //       <h2 className="activity-title">Activities</h2>
-  //       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-  //         <DialogTrigger>
-  //           <i
-  //             className="fas fa-plus"
-  //             onClick={() => setIsDialogOpen(true)}
-  //           ></i>
-  //         </DialogTrigger>
-  //         <DialogContent>
-  //           <DialogHeader>
-  //             <DialogTitle>Add a New Activity Group</DialogTitle>
-  //             <DialogDescription>
-  //               Please enter the title of your new Activity Group.
-  //             </DialogDescription>
-  //             <Input
-  //               value={newActivityTitle}
-  //               onChange={(e) => setNewActivityTitle(e.target.value)}
-  //               placeholder="Enter activity title"
-  //             />
-  //             <Button onClick={handleAddActivity}>Create</Button>
-  //           </DialogHeader>
-  //         </DialogContent>
-  //       </Dialog>
-  //     </div>
-
-  //     <div className="activity-list">
-  //       {activityGroups.map((group) => (
-  //         <div key={group.id} className="activity-group">
-  //           <div className="group-header" onClick={() => toggleGroup(group.id)}>
-  //             <span className="group-title">{group.title}</span>
-  //             <DropdownMenu>
-  //               <DropdownMenuTrigger>
-  //                 <i className="fa-solid fa-ellipsis group-options"></i>
-  //               </DropdownMenuTrigger>
-  //               <DropdownMenuContent>
-  //                 <DropdownMenuItem
-  //                   onClick={() => handleRemoveActivityGroup(group.id)}
-  //                 >
-  //                   Delete Group
-  //                 </DropdownMenuItem>
-  //                 <DropdownMenuSeparator />
-  //                 <DropdownMenuItem>Add to Daily Plan</DropdownMenuItem>
-  //               </DropdownMenuContent>
-  //             </DropdownMenu>
-  //           </div>
-
-  //           {openGroup === group.id && (
-  //             <div className="activity-items-container space-y-4 pt-2">
-  //               {group.activities.map((activity, index) => (
-  //                 <div
-  //                   key={index}
-  //                   className="activity-item relative bg-gray-100 border border-gray-300 p-4 rounded-lg shadow-sm"
-  //                 >
-  //                   <div className="flex justify-between items-center">
-  //                     <span className="text-xl font-semibold text-gray-800">
-  //                       {activity.Name}
-  //                     </span>
-  //                     <DropdownMenu>
-  //                       <DropdownMenuTrigger>
-  //                         <i className="fa-solid fa-ellipsis cursor-pointer text-gray-500 absolute top-2 right-3"></i>
-  //                       </DropdownMenuTrigger>
-  //                       <DropdownMenuContent>
-  //                         <DropdownMenuItem
-  //                           onClick={() =>
-  //                             handleRemoveActivity(group.id, index)
-  //                           }
-  //                         >
-  //                           Remove
-  //                         </DropdownMenuItem>
-  //                         <DropdownMenuSeparator />
-  //                         <DropdownMenuItem>Add To Daily Plan</DropdownMenuItem>
-  //                       </DropdownMenuContent>
-  //                     </DropdownMenu>
-  //                   </div>
-  //                   <h1 className="text-sm text-gray-600 mb-4">
-  //                     {activity.Address}
-  //                   </h1>
-  //                 </div>
-  //               ))}
-  //             </div>
-  //           )}
-  //         </div>
-  //       ))}
-  //     </div>
-  //   </>
-  // );
 };
+
 export default ActivitySelector;

--- a/frontend/src/app/components/dailyActivities.tsx
+++ b/frontend/src/app/components/dailyActivities.tsx
@@ -1,35 +1,90 @@
-import { Place } from "@/lib/utils";
+"use client";
+
+import { useState } from "react";
+import { ActivityGroup, Place } from "@/lib/utils";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 
+type Day = "Day 1" | "Day 2" | "Day 3";
+
 interface DailyActivitiesProps {
-  dailyPlan: Place[];
-  setDailyPlan: (activities: Place[]) => void;
+  dailyPlans: Record<Day, Place[]>;
+  setDailyPlans: (plans: Record<Day, Place[]>) => void;
+  activityGroups: ActivityGroup[];
 }
 
-const DailyActivities = ({ dailyPlan, setDailyPlan }: DailyActivitiesProps) => {
-  // Handler to clear the daily plan
-  const clearDailyPlan = () => setDailyPlan([]);
+const DailyActivities = ({
+  dailyPlans,
+  setDailyPlans,
+  activityGroups,
+}: DailyActivitiesProps) => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<Day>("Day 1");
+
+  // Add activity to the selected date's daily plan
+  const addToDailyPlan = (activity: Place) => {
+    if (
+      !dailyPlans[selectedDate].some((a) => a.Place_ID === activity.Place_ID)
+    ) {
+      setDailyPlans({
+        ...dailyPlans,
+        [selectedDate]: [...dailyPlans[selectedDate], activity],
+      });
+    }
+    setIsDialogOpen(false); // Close dialog after adding
+  };
+
+  // Remove activity from a specific day's plan
+  const removeFromDailyPlan = (date: Day, activityId: string) => {
+    setDailyPlans({
+      ...dailyPlans,
+      [date]: dailyPlans[date].filter((a) => a.Place_ID !== activityId),
+    });
+  };
 
   return (
-    <div className="daily-activities-container">
-      <h2 className="text-xl font-bold mb-4">Daily Plan</h2>
+    <div className="daily-activities p-4 bg-white shadow-md rounded-lg">
+      <h3 className="text-xl font-semibold mb-4">Daily Plan</h3>
 
-      {/* Display Daily Plan Activities */}
-      <div className="daily-plan-list mb-6">
-        {dailyPlan.length > 0 ? (
-          dailyPlan.map((activity) => (
+      {/* Date Selector */}
+      <div className="flex space-x-4 mb-4">
+        {(["Day 1", "Day 2", "Day 3"] as Day[]).map((day) => (
+          <Button
+            key={day}
+            variant={selectedDate === day ? "default" : "outline"}
+            onClick={() => setSelectedDate(day)}
+            className={`flex-1 ${
+              selectedDate === day ? "bg-blue-500 text-white" : "text-blue-500"
+            }`}
+          >
+            {day}
+          </Button>
+        ))}
+      </div>
+
+      {/* Display Daily Plan Activities for Selected Date */}
+      <div className="daily-plan-list mb-6 h-40 overflow-y-auto border border-gray-200 rounded-lg p-4 bg-gray-50">
+        {dailyPlans[selectedDate].length > 0 ? (
+          dailyPlans[selectedDate].map((activity) => (
             <div
               key={activity.Place_ID}
-              className="daily-plan-item bg-gray-100 p-4 rounded-lg mb-2"
+              className="daily-plan-item bg-white shadow-sm rounded-lg p-4 mb-2 "
             >
-              <h3 className="text-lg font-medium">{activity.Name}</h3>
+              <h3 className="text-lg font-medium text-gray-800">
+                {activity.Name}
+              </h3>
               <p className="text-sm text-gray-600">{activity.Address}</p>
+
               <button
-                className="text-red-500 text-sm"
+                className="text-red-500 text-sm hover:underline mt-2"
                 onClick={() =>
-                  setDailyPlan(
-                    dailyPlan.filter((a) => a.Place_ID !== activity.Place_ID)
-                  )
+                  removeFromDailyPlan(selectedDate, activity.Place_ID!)
                 }
               >
                 Remove
@@ -37,16 +92,61 @@ const DailyActivities = ({ dailyPlan, setDailyPlan }: DailyActivitiesProps) => {
             </div>
           ))
         ) : (
-          <div className="flex flex-col items-center">
-            <p className="text-sm text-gray-500 mb-4">
-              No activities added to your daily plan yet.
-            </p>
-            <Button onClick={clearDailyPlan} variant="outline">
-              Add to Daily Plan
-            </Button>
-          </div>
+          <p className="text-sm text-gray-500">
+            No activities added to {selectedDate} yet.
+          </p>
         )}
       </div>
+
+      {/* Button to open the Add to Daily Plan modal */}
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogTrigger asChild>
+          <Button onClick={() => setIsDialogOpen(true)} className="w-full">
+            Add to Daily Plan
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Select an Activity to Add</DialogTitle>
+          </DialogHeader>
+
+          {/* Scrollable Activity Groups */}
+          <div className="activity-groups overflow-y-auto max-h-[400px]">
+            {activityGroups.map((group) => (
+              <div key={group.id} className="activity-group mb-4">
+                <h4 className="font-semibold text-lg text-gray-700">
+                  {group.title}
+                </h4>
+                {group.activities.length > 0 ? (
+                  group.activities.map((activity) => (
+                    <div
+                      key={activity.Place_ID}
+                      className="activity-item p-3 bg-gray-200 rounded-lg mt-2 transition-shadow hover:shadow-lg"
+                    >
+                      <h5 className="text-sm font-medium text-gray-800">
+                        {activity.Name}
+                      </h5>
+                      <p className="text-xs text-gray-600">
+                        {activity.Address}
+                      </p>
+                      <Button
+                        className="mt-2 bg-blue-500 text-white hover:bg-blue-600"
+                        onClick={() => addToDailyPlan(activity)}
+                      >
+                        Add to Plan
+                      </Button>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-xs text-gray-500">
+                    No activities in this group.
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/frontend/src/app/components/dailyActivities.tsx
+++ b/frontend/src/app/components/dailyActivities.tsx
@@ -1,0 +1,54 @@
+import { Place } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+interface DailyActivitiesProps {
+  dailyPlan: Place[];
+  setDailyPlan: (activities: Place[]) => void;
+}
+
+const DailyActivities = ({ dailyPlan, setDailyPlan }: DailyActivitiesProps) => {
+  // Handler to clear the daily plan
+  const clearDailyPlan = () => setDailyPlan([]);
+
+  return (
+    <div className="daily-activities-container">
+      <h2 className="text-xl font-bold mb-4">Daily Plan</h2>
+
+      {/* Display Daily Plan Activities */}
+      <div className="daily-plan-list mb-6">
+        {dailyPlan.length > 0 ? (
+          dailyPlan.map((activity) => (
+            <div
+              key={activity.Place_ID}
+              className="daily-plan-item bg-gray-100 p-4 rounded-lg mb-2"
+            >
+              <h3 className="text-lg font-medium">{activity.Name}</h3>
+              <p className="text-sm text-gray-600">{activity.Address}</p>
+              <button
+                className="text-red-500 text-sm"
+                onClick={() =>
+                  setDailyPlan(
+                    dailyPlan.filter((a) => a.Place_ID !== activity.Place_ID)
+                  )
+                }
+              >
+                Remove
+              </button>
+            </div>
+          ))
+        ) : (
+          <div className="flex flex-col items-center">
+            <p className="text-sm text-gray-500 mb-4">
+              No activities added to your daily plan yet.
+            </p>
+            <Button onClick={clearDailyPlan} variant="outline">
+              Add to Daily Plan
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DailyActivities;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -18,14 +18,30 @@ export default function Home() {
   const [activityGroups, setActivityGroups] = useState([
     new ActivityGroup("group-id-1", "Snorkelling", []),
     new ActivityGroup("group-id-2", "Beaches", []),
-    new ActivityGroup("group-id-3", "Resturants", []),
+    new ActivityGroup("group-id-3", "Restaurants", []),
   ]);
 
-  const [dailyPlan, setDailyPlan] = useState<Place[]>([]);
+  // Update this state to hold plans for multiple days
+  const [dailyPlans, setDailyPlans] = useState<
+    Record<"Day 1" | "Day 2" | "Day 3", Place[]>
+  >({
+    "Day 1": [],
+    "Day 2": [],
+    "Day 3": [],
+  });
 
-  const addToDailyPlan = (activity: Place) => {
-    if (!dailyPlan.some((a) => a.Place_ID === activity.Place_ID)) {
-      setDailyPlan((prevDailyPlan) => [...prevDailyPlan, activity]);
+  // Function to add activity to a specific day's plan
+  const addToDailyPlan = (
+    activity: Place,
+    selectedDate: "Day 1" | "Day 2" | "Day 3"
+  ) => {
+    if (
+      !dailyPlans[selectedDate].some((a) => a.Place_ID === activity.Place_ID)
+    ) {
+      setDailyPlans((prevDailyPlans) => ({
+        ...prevDailyPlans,
+        [selectedDate]: [...prevDailyPlans[selectedDate], activity],
+      }));
     }
   };
 
@@ -48,7 +64,9 @@ export default function Home() {
                 <ActivitySelector
                   activityGroups={activityGroups}
                   setActivityGroups={setActivityGroups}
-                  addToDailyPlan={addToDailyPlan} // Pass the function
+                  addToDailyPlan={(activity) =>
+                    addToDailyPlan(activity, "Day 1")
+                  } // Example for Day 1
                 />
               </aside>
 
@@ -64,8 +82,9 @@ export default function Home() {
               <section className="schedule">
                 <h3>Daily Schedule</h3>
                 <DailyActivities
-                  dailyPlan={dailyPlan}
-                  setDailyPlan={setDailyPlan}
+                  dailyPlans={dailyPlans}
+                  setDailyPlans={setDailyPlans}
+                  activityGroups={activityGroups}
                 />
               </section>
             </div>
@@ -76,3 +95,83 @@ export default function Home() {
     </div>
   );
 }
+
+// "use client";
+// import styles from "./page.module.css";
+// import GoogleMapComponent from "./components/map";
+// import SearchBar from "./components/search";
+// import NavBar from "./components/navbar";
+// import ActivitySelector from "./components/activitySelector";
+// import Homebase from "./components/homebase";
+// import { useState } from "react";
+// import { APIProvider } from "@vis.gl/react-google-maps";
+// import { ActivityGroup, Place } from "@/lib/utils";
+// import DailyActivities from "./components/dailyActivities";
+
+// export default function Home() {
+//   const [homebaseLocation, setHomebaseLocation] =
+//     useState<google.maps.places.PlaceResult | null>(null);
+//   const [selectedPlace, setSelectedPlace] =
+//     useState<google.maps.places.PlaceResult | null>(null);
+//   const [activityGroups, setActivityGroups] = useState([
+//     new ActivityGroup("group-id-1", "Snorkelling", []),
+//     new ActivityGroup("group-id-2", "Beaches", []),
+//     new ActivityGroup("group-id-3", "Resturants", []),
+//   ]);
+
+//   const [dailyPlan, setDailyPlan] = useState<Place[]>([]);
+
+//   const addToDailyPlan = (activity: Place) => {
+//     if (!dailyPlan.some((a) => a.Place_ID === activity.Place_ID)) {
+//       setDailyPlan((prevDailyPlan) => [...prevDailyPlan, activity]);
+//     }
+//   };
+
+//   return (
+//     <div>
+//       <NavBar />
+//       <APIProvider apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!}>
+//         <div className={styles.page}>
+//           <main className={styles.main}>
+//             <div className="container">
+//               <header className="header">
+//                 <Homebase
+//                   homebaseLocation={homebaseLocation}
+//                   onHomebaseSelect={setHomebaseLocation}
+//                 />
+//                 <SearchBar onPlaceSelect={setSelectedPlace} />
+//               </header>
+
+//               <aside className="sidebar">
+//                 <ActivitySelector
+//                   activityGroups={activityGroups}
+//                   setActivityGroups={setActivityGroups}
+//                   addToDailyPlan={addToDailyPlan} // Pass the function
+//                 />
+//               </aside>
+
+//               <section className="map">
+//                 <GoogleMapComponent
+//                   selectedPlace={selectedPlace}
+//                   homebaseLocation={homebaseLocation}
+//                   activityGroups={activityGroups}
+//                   setActivityGroups={setActivityGroups}
+//                 />
+//               </section>
+
+//               <section className="schedule">
+//                 <h3>Daily Schedule</h3>
+//                 <DailyActivities
+//                   dailyPlan={dailyPlan}
+//                   setDailyPlan={setDailyPlan}
+//                   activityGroups={activityGroups}
+//                 />
+//               </section>
+//             </div>
+//           </main>
+//           <footer className={styles.footer}></footer>
+//         </div>
+//       </APIProvider>
+//     </div>
+//   );
+// }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 import styles from "./page.module.css";
 import GoogleMapComponent from "./components/map";
 import SearchBar from "./components/search";
@@ -7,58 +7,72 @@ import ActivitySelector from "./components/activitySelector";
 import Homebase from "./components/homebase";
 import { useState } from "react";
 import { APIProvider } from "@vis.gl/react-google-maps";
-import { ActivityGroup } from "@/lib/utils";
+import { ActivityGroup, Place } from "@/lib/utils";
+import DailyActivities from "./components/dailyActivities";
 
 export default function Home() {
-  const [homebaseLocation, setHomebaseLocation] = useState<google.maps.places.PlaceResult | null>(null);
-  const [selectedPlace, setSelectedPlace] = useState<google.maps.places.PlaceResult | null>(null);
+  const [homebaseLocation, setHomebaseLocation] =
+    useState<google.maps.places.PlaceResult | null>(null);
+  const [selectedPlace, setSelectedPlace] =
+    useState<google.maps.places.PlaceResult | null>(null);
   const [activityGroups, setActivityGroups] = useState([
     new ActivityGroup("group-id-1", "Snorkelling", []),
     new ActivityGroup("group-id-2", "Beaches", []),
     new ActivityGroup("group-id-3", "Resturants", []),
   ]);
-  
+
+  const [dailyPlan, setDailyPlan] = useState<Place[]>([]);
+
+  const addToDailyPlan = (activity: Place) => {
+    if (!dailyPlan.some((a) => a.Place_ID === activity.Place_ID)) {
+      setDailyPlan((prevDailyPlan) => [...prevDailyPlan, activity]);
+    }
+  };
+
   return (
     <div>
-      <NavBar/>
+      <NavBar />
       <APIProvider apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!}>
         <div className={styles.page}>
-          
-          <main className= {styles.main}>
-
+          <main className={styles.main}>
             <div className="container">
-
               <header className="header">
-                <Homebase  homebaseLocation = {homebaseLocation} onHomebaseSelect={setHomebaseLocation}/>
-                <SearchBar onPlaceSelect={setSelectedPlace}/>
+                <Homebase
+                  homebaseLocation={homebaseLocation}
+                  onHomebaseSelect={setHomebaseLocation}
+                />
+                <SearchBar onPlaceSelect={setSelectedPlace} />
               </header>
-            
+
               <aside className="sidebar">
-                <ActivitySelector activityGroups={activityGroups} setActivityGroups={setActivityGroups}/>
+                <ActivitySelector
+                  activityGroups={activityGroups}
+                  setActivityGroups={setActivityGroups}
+                  addToDailyPlan={addToDailyPlan} // Pass the function
+                />
               </aside>
 
               <section className="map">
-                <GoogleMapComponent selectedPlace={selectedPlace}  homebaseLocation= {homebaseLocation} activityGroups={activityGroups} setActivityGroups={setActivityGroups}/>
+                <GoogleMapComponent
+                  selectedPlace={selectedPlace}
+                  homebaseLocation={homebaseLocation}
+                  activityGroups={activityGroups}
+                  setActivityGroups={setActivityGroups}
+                />
               </section>
 
               <section className="schedule">
-                <h3>Daily Schedule: Oct. 2, 2024</h3>
-                <ul>
-                  <li>Location 1</li>
-                  <li>Location 2</li>
-                  <li>Location 3</li>
-                </ul>
+                <h3>Daily Schedule</h3>
+                <DailyActivities
+                  dailyPlan={dailyPlan}
+                  setDailyPlan={setDailyPlan}
+                />
               </section>
             </div>
-
-          </main>    
-          <footer className={styles.footer}>
-            
-          </footer>
+          </main>
+          <footer className={styles.footer}></footer>
         </div>
       </APIProvider>
-
     </div>
-    
   );
 }


### PR DESCRIPTION
I added the daily activities and there functionality at the bottom we have three days with a button that lets users add an activity. the  three day's are buttons themselves which store a state of the current activities added to the list. 
<img width="1251" alt="Screenshot 2024-11-03 at 9 35 20 PM" src="https://github.com/user-attachments/assets/f5537ac5-cb93-4ebc-88fc-0ccc057c1363">

this is the modal that will pop up allowing the user to select activities from their activity group
<img width="1792" alt="Screenshot 2024-11-03 at 9 36 24 PM" src="https://github.com/user-attachments/assets/e88e8a70-9e5e-4977-b7fb-1a83deda855e">

the user can scroll through their current activities on their day to see what is added
<img width="1232" alt="Screenshot 2024-11-03 at 9 36 37 PM" src="https://github.com/user-attachments/assets/837d8913-1662-40ac-89cb-91ac1d784c1d">

each day has there own activities stored 
<img width="1239" alt="Screenshot 2024-11-03 at 9 37 59 PM" src="https://github.com/user-attachments/assets/bdd15cde-371f-4702-a985-871f3a55334e">
<img width="1239" alt="Screenshot 2024-11-03 at 9 38 05 PM" src="https://github.com/user-attachments/assets/bc3ea591-9f15-4eb4-982b-1fb83ddf1da6">
<img width="1247" alt="Screenshot 2024-11-03 at 9 38 15 PM" src="https://github.com/user-attachments/assets/8d1aec4f-33b3-4d73-bcdb-1bd7d4f52909">

