### PR TITLE
API endpoints for Daily Plan

### DIFF
--- a/backend/info_manager_dict.py
+++ b/backend/info_manager_dict.py
@@ -1,10 +1,12 @@
 import dataclasses
 import uuid
+from typing import Optional
 
 @dataclasses.dataclass
 class Place:
     name: str
     ID: str
+    daily_plan_id: Optional[str]
     latitude: float
     longitude: float
 
@@ -27,7 +29,7 @@ class InfoManagerDict:
         return self.data[user_id]
     
     def add_place(self, activity_group: str, user_id: str, name: str, id: str, latitude: float, longitude: float):
-        self.data[user_id].places[activity_group].append(Place(name, id, latitude, longitude))
+        self.data[user_id].places[activity_group].append(Place(name, id, None, latitude, longitude))
 
     def get_places(self, user_id: str):
         return [place for places in self.data[user_id].places.values() for place in places]
@@ -65,3 +67,23 @@ class InfoManagerDict:
             }
             for group_name, places in self.data[user_id].places.items()
         ]
+    
+    def get_daily_plan(self, user_id: str, daily_plan_id: str):
+        places = []
+        for place_list in self.data[user_id].places.values():
+            for place in place_list:
+                if place.daily_plan_id == daily_plan_id:
+                    places.append(place)
+        return places
+    
+    def add_to_daily_plan(self, user_id: str, daily_plan_id: str, place_id: str):
+        for place_list in self.data[user_id].places.values():
+            for place in place_list:
+                if place.ID == place_id:
+                    place.daily_plan_id = daily_plan_id
+
+    def remove_from_daily_plan(self, user_id: str, place_id: str):
+        for place_list in self.data[user_id].places.values():
+            for place in place_list:
+                if place.ID == place_id:
+                    place.daily_plan_id = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -209,14 +209,16 @@ def add_place_to_daily_plan(user_id: Annotated[str, Body()],
     return { "message" : "success" }
 
 @app.delete("/place/daily-plan")
-def remove_place_from_daily_plan(user_id: Annotated[str, Body()], place_id: Annotated[str, Body()]):
+def remove_place_from_daily_plan(user_id: Annotated[str, Body()], 
+                                 place_id: Annotated[str, Body()],
+                                 daily_plan_id: Annotated[str, Body()]):
     """
     Takes in a user ID, and place ID from the frontend, removes the place from it's the daily plan.
     """
     if user_id not in db.data:
         raise HTTPException(status_code=404, detail="User not found")
     
-    db.remove_from_daily_plan(user_id, place_id)
+    db.remove_from_daily_plan(user_id, daily_plan_id, place_id)
 
     return { "message" : "success" }
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -200,7 +200,6 @@ def add_place_to_daily_plan(user_id: Annotated[str, Body()],
                             daily_plan_id: Annotated[str, Body()]):
     """
     Takes in a user ID, place ID, and daily plan ID from the frontend, adds the place to the daily plan.
-    Subject to change.
     """
     if user_id not in db.data:
         raise HTTPException(status_code=404, detail="User not found")
@@ -213,7 +212,6 @@ def add_place_to_daily_plan(user_id: Annotated[str, Body()],
 def remove_place_from_daily_plan(user_id: Annotated[str, Body()], place_id: Annotated[str, Body()]):
     """
     Takes in a user ID, and place ID from the frontend, removes the place from it's the daily plan.
-    Subject to change.
     """
     if user_id not in db.data:
         raise HTTPException(status_code=404, detail="User not found")
@@ -226,7 +224,6 @@ def remove_place_from_daily_plan(user_id: Annotated[str, Body()], place_id: Anno
 def get_daily_plan(user_id: Annotated[str, Body()], daily_plan_id: Annotated[str, Body()]):
     """
     Takes in a user ID and an daily plan ID from the frontend, returns the daily plan from the user's places.
-    Subject to change.
     """
     if user_id not in db.data:
         raise HTTPException(status_code=404, detail="User not found")
@@ -242,3 +239,39 @@ def get_daily_plan(user_id: Annotated[str, Body()], daily_plan_id: Annotated[str
         )
         for place in places
     ] }
+
+@app.get("/daily-plan/all")
+def get_all_daily_plan_ids(user_id: Annotated[str, Body()]):
+    """
+    Takes in a user id from the frontend, returns a list of all the daily plans the user has.
+    """
+    if user_id not in db.data:
+        raise HTTPException(status_code=404, detail="User not found")
+    
+    dp_list = db.get_daily_plan_list(user_id)
+
+    return { "daily_plans" : dp_list }
+
+@app.delete("/daily-plan")
+def delete_daily_plan(user_id: Annotated[str, Body()], daily_plan_id: Annotated[str, Body()]):
+    """
+    Takes in a user id and daily plan id front the frontend, deletes the associated daily plan
+    """
+    if user_id not in db.data:
+        raise HTTPException(status_code=404, detail="User not found")
+    
+    db.delete_daily_plan(user_id, daily_plan_id)
+
+    return { "message" : "success" }
+
+@app.post("/daily-plan")
+def add_daily_plan(user_id: Annotated[str, Body()], daily_plan_id: Annotated[str, Body()]):
+    """
+    Takes in a user id and daily plan id front the frontend, creates a daily plan with that id
+    """
+    if user_id not in db.data:
+        raise HTTPException(status_code=404, detail="User not found")
+    
+    db.create_daily_plan(user_id, daily_plan_id)
+
+    return { "message" : "success" }

--- a/backend/tests/test_info_manager_dict.py
+++ b/backend/tests/test_info_manager_dict.py
@@ -82,6 +82,28 @@ class TestInfoManagerDict(unittest.TestCase):
         self.assertFalse(self.manager.activity_group_exists(user_id, "parks"))
         self.assertTrue(self.manager.activity_group_exists(user_id, "squares"))
 
+    def test_add_to_daily_plan(self):
+        user_id = self.manager.add_user(40.7128, -74.0060)
+        self.manager.add_activity_group(user_id, "parks")
+        self.manager.add_place("parks", user_id, "Central Park", "park1", 40.7829, -73.9654)
+
+        self.manager.add_to_daily_plan(user_id, "morning", "park1")
+        places_in_plan = self.manager.get_daily_plan(user_id, "morning")
+        
+        self.assertEqual(len(places_in_plan), 1)
+        self.assertEqual(places_in_plan[0].name, "Central Park")
+        self.assertEqual(places_in_plan[0].daily_plan_id, "morning")
+
+    def test_remove_from_daily_plan(self):
+        user_id = self.manager.add_user(40.7128, -74.0060)
+        self.manager.add_activity_group(user_id, "parks")
+        self.manager.add_place("parks", user_id, "Central Park", "park1", 40.7829, -73.9654)
+        self.manager.add_to_daily_plan(user_id, "morning", "park1")
+
+        self.manager.remove_from_daily_plan(user_id, "park1")
+        places_in_plan = self.manager.get_daily_plan(user_id, "morning")
+        
+        self.assertEqual(len(places_in_plan), 0)
+
 if __name__ == '__main__':
     unittest.main()
-

--- a/backend/tests/test_info_manager_dict.py
+++ b/backend/tests/test_info_manager_dict.py
@@ -10,6 +10,7 @@ class TestInfoManagerDict(unittest.TestCase):
         self.assertIn(user_id, self.manager.data)
         self.assertEqual(self.manager.data[user_id].home, (40.7128, -74.0060))
         self.assertEqual(len(self.manager.data[user_id].places), 0)
+        self.assertEqual(len(self.manager.data[user_id].daily_plans), 0)
 
     def test_add_place(self):
         user_id = self.manager.add_user(40.7128, -74.0060)
@@ -86,24 +87,32 @@ class TestInfoManagerDict(unittest.TestCase):
         user_id = self.manager.add_user(40.7128, -74.0060)
         self.manager.add_activity_group(user_id, "parks")
         self.manager.add_place("parks", user_id, "Central Park", "park1", 40.7829, -73.9654)
+        self.manager.create_daily_plan(user_id, "morning")
 
         self.manager.add_to_daily_plan(user_id, "morning", "park1")
         places_in_plan = self.manager.get_daily_plan(user_id, "morning")
         
         self.assertEqual(len(places_in_plan), 1)
         self.assertEqual(places_in_plan[0].name, "Central Park")
-        self.assertEqual(places_in_plan[0].daily_plan_id, "morning")
 
     def test_remove_from_daily_plan(self):
         user_id = self.manager.add_user(40.7128, -74.0060)
         self.manager.add_activity_group(user_id, "parks")
         self.manager.add_place("parks", user_id, "Central Park", "park1", 40.7829, -73.9654)
+        self.manager.create_daily_plan(user_id, "morning")
         self.manager.add_to_daily_plan(user_id, "morning", "park1")
 
-        self.manager.remove_from_daily_plan(user_id, "park1")
+        self.manager.remove_from_daily_plan(user_id, "morning", "park1")
         places_in_plan = self.manager.get_daily_plan(user_id, "morning")
         
         self.assertEqual(len(places_in_plan), 0)
+
+    def test_delete_daily_plan(self):
+        user_id = self.manager.add_user(40.7128, -74.0060)
+        self.manager.create_daily_plan(user_id, "morning")
+        self.manager.delete_daily_plan(user_id, "morning")
+
+        self.assertNotIn("morning", self.manager.data[user_id].daily_plans)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added prototype methods for daily plan endpoints (subject to change).

Modified the info_manager to accomodate the daily plan information, and edited related calls. Updated the tests to reflect the new functionality.

Added a stub version of route where the places related to the daily plan specified are fetched.

<img width="1399" alt="スクリーンショット 2024-11-14 22 54 24" src="https://github.com/user-attachments/assets/f6f9cbe3-286b-43d2-aba4-36fa5c7febfb">

<img width="1399" alt="スクリーンショット 2024-11-14 22 54 36" src="https://github.com/user-attachments/assets/641c35ba-540d-4e3a-b9a1-98f801dcf93a">

<img width="1399" alt="スクリーンショット 2024-11-14 22 54 47" src="https://github.com/user-attachments/assets/1dba0f88-4abd-4202-9a61-6893e8bec069">
